### PR TITLE
Short open tag bug fix

### DIFF
--- a/src/views/xml.blade.php
+++ b/src/views/xml.blade.php
@@ -1,4 +1,4 @@
-{!! '<?xml' !!} version="1.0" encoding="UTF-8"?>
+{!! '<'.'?xml' !!} version="1.0" encoding="UTF-8"?>
 <methodCall>
     <methodName>weblogUpdates.ping</methodName>
     <params>


### PR DESCRIPTION
При включенном short open tag в php кидало FatalError
![ошибка](https://www.dropbox.com/s/jt35mryyuxgkhbi/%D0%A1%D0%BA%D1%80%D0%B8%D0%BD%D1%88%D0%BE%D1%82%202015-09-20%2001.33.39.png?dl=1)
