### PR TITLE
php artisan vendor:publish instructions added to readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ When update completed, add to your `config/app.conf` file to `providers` section
 ]
 ```
 
+If you want to use `Pinger` facade, add to same file at the `aliases` section
+
+``` PHP
+'aliases' => [
+    // ...
+  'Pinger' => Garf\LaravelPinger\PingerFacade::class,
+]
+`
 ### Publish with artsian
 
 ``` PHP
@@ -41,14 +49,7 @@ Publishes a pinger.php file to config directory. Add and remove all your ping si
 Be sure to review the ping responses from the ping sites you add because there are many ping sites 
 and do not all provide a uniform response. Some may require additional parameters. Some may stop working.
 
-If you want to use `Pinger` facade, add to same file at the `aliases` section
-
-``` PHP
-'aliases' => [
-    // ...
-  'Pinger' => Garf\LaravelPinger\PingerFacade::class,
-]
-```
+``
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ When update completed, add to your `config/app.conf` file to `providers` section
 ]
 ```
 
+### Publish with artsian
+
+``` PHP
+php artisan vendor:publish
+```
+Publishes a pinger.php file to config directory. Add and remove all your ping sites in this file. 
+Be sure to review the ping responses from the ping sites you add because there are many ping sites 
+and do not all provide a uniform response. Some may require additional parameters. Some may stop working.
+
 If you want to use `Pinger` facade, add to same file at the `aliases` section
 
 ``` PHP

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ If you want to use `Pinger` facade, add to same file at the `aliases` section
     // ...
   'Pinger' => Garf\LaravelPinger\PingerFacade::class,
 ]
-`
+```
+
 ### Publish with artsian
 
 ``` PHP

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you want to use `Pinger` facade, add to same file at the `aliases` section
 ]
 ```
 
-### Publish with artsian
+## Publish with artsian
 
 ``` PHP
 php artisan vendor:publish
@@ -49,8 +49,6 @@ php artisan vendor:publish
 Publishes a pinger.php file to config directory. Add and remove all your ping sites in this file. 
 Be sure to review the ping responses from the ping sites you add because there are many ping sites 
 and do not all provide a uniform response. Some may require additional parameters. Some may stop working.
-
-``
 
 ## Usage
 


### PR DESCRIPTION
php artisan vendor:publish instructions added to readme 

This important part of the instructions for the package were not in the readme.md file before. 